### PR TITLE
Specify san when issuing the openssl command

### DIFF
--- a/fs_overlay/opt/certs_manager/certs_manager.rb
+++ b/fs_overlay/opt/certs_manager/certs_manager.rb
@@ -56,6 +56,7 @@ class CertsManager
           mkdir(domain)
           OpenSSL.ensure_domain_key(domain)
           OpenSSL.create_csr(domain)
+          OpenSSL.create_san(domain)
           if ACME.sign(domain)
             chain_certs(domain)
             Nginx.config_ssl(domain)

--- a/fs_overlay/opt/certs_manager/lib/open_ssl.rb
+++ b/fs_overlay/opt/certs_manager/lib/open_ssl.rb
@@ -18,6 +18,10 @@ module OpenSSL
     system "openssl req -new -sha256 -key #{domain.key_path} -subj '/CN=#{domain.name}' > #{domain.csr_path}"
   end
 
+  def self.create_san(domain)
+    system "echo subjectAltName=DNS:#{domain.name} > #{domain.san_path}"
+  end
+
   def self.need_to_sign_or_renew?(domain)
     return true if NAConfig.force_renew?
 
@@ -47,6 +51,7 @@ module OpenSSL
     openssl x509 -req -days 90 \
       -in #{domain.csr_path} \
       -signkey #{domain.key_path} \
+      -extfile #{domain.san_path} \
       -out #{domain.signed_cert_path}
     EOC
 

--- a/fs_overlay/opt/certs_manager/models/domain.rb
+++ b/fs_overlay/opt/certs_manager/models/domain.rb
@@ -31,6 +31,10 @@ class Domain
     File.join(dir, 'domain.key')
   end
 
+  def san_path
+    File.join(dir, 'san.ext')
+  end
+
   def htaccess_path
     File.join(dir, 'htaccess')
   end


### PR DESCRIPTION
- openssl コマンドで生成される証明書がSANに対応していなかったので、SANを利用できるように拡張
- [参考](http://portaltan.hatenablog.com/entry/2017/10/16/174619)